### PR TITLE
Fixing login

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,10 +76,10 @@ def create_app(test_config=None):
         if form.validate_on_submit():
             user= User.query.filter_by(email=form.email.data).first()
             if user and bcrypt.check_password_hash(user.password, form.password.data):
+                print('Login succeeds!!')
                 login_user(user, remember=form.remember.data)
-                return redirect(url_for('index'))
-            else:    
-               flash('Login Unsuccessful. Please check email and password or proceed to register first.', 'danger')     
+                return redirect(url_for('home'))
+            flash('Login Unsuccessful. Please check email and password or proceed to register first.', 'danger')     
         return render_template('login.html', title= 'Log In', form= form)
     
     #logout page

--- a/models.py
+++ b/models.py
@@ -176,7 +176,7 @@ class User(db.Model, UserMixin):
     username= db.Column(db.String(20), unique=True, nullable=False)
     email= db.Column(db.String(30), unique=True, nullable=False)
     image_file= db.Column(db.String(20))
-    password= db.Column(db.String(60), nullable= False)
+    password= db.Column(db.String(100), nullable= False)
     pets = db.relationship('Pet', backref='pet_custodian', lazy=True)
     
     def __repr__(self):


### PR DESCRIPTION
Fixing login: invalid salt error is due to the size of the column in the DB. Must be 100 characters to hold the whole hashed value, otherwise it gets truncated and is invalid. 

I needed to stop the app, uncomment 'db_drop_and_create_all()' line and rerun flask to make the model change take effect.
Now you do not need to do it again because we use the same database, the db is already correct.

Also fixed the redirect after login to the actual home route